### PR TITLE
Set pixels brightness; recall display brightness setting in auto dim mode

### DIFF
--- a/adafruit_pybadger.py
+++ b/adafruit_pybadger.py
@@ -117,7 +117,7 @@ class PyBadger:
         # Count is hardcoded - should be based on board ID, currently no board info for PyBadge LC
         neopixel_count = 5
         self._neopixels = neopixel.NeoPixel(board.NEOPIXEL, neopixel_count,
-                                brightness=pixels_brightness, pixel_order=neopixel.GRB)
+                                            brightness=pixels_brightness, pixel_order=neopixel.GRB)
 
         # Auto dim display based on movement
         self._last_accelerometer = None

--- a/adafruit_pybadger.py
+++ b/adafruit_pybadger.py
@@ -103,7 +103,7 @@ class PyBadger:
 
         # Display
         self.display = board.DISPLAY
-        self._brightness_value = 1.0
+        self._display_brightness = 1.0
 
         # Light sensor
         self._light_sensor = analogio.AnalogIn(board.A7)
@@ -155,7 +155,7 @@ class PyBadger:
                 self.display.brightness = 0.1
                 self._start_time = current_time
         else:
-            self.display.brightness = self._brightness_value
+            self.display.brightness = self._display_brightness
 
     @property
     def pixels(self):
@@ -217,7 +217,7 @@ class PyBadger:
 
     @brightness.setter
     def brightness(self, value):
-        self._brightness_value = value
+        self._display_brightness = value
         self.display.brightness = value
 
     # pylint: disable=too-many-locals

--- a/adafruit_pybadger.py
+++ b/adafruit_pybadger.py
@@ -81,7 +81,7 @@ class PyBadger:
     BUTTON_A = const(2)
     BUTTON_B = const(1)
 
-    def __init__(self, i2c=None):
+    def __init__(self, i2c=None, *, pixels_brightness=1.0):
         # Accelerometer
         if i2c is None:
             try:
@@ -103,6 +103,7 @@ class PyBadger:
 
         # Display
         self.display = board.DISPLAY
+        self._brightness_value = 1.0
 
         # Light sensor
         self._light_sensor = analogio.AnalogIn(board.A7)
@@ -116,7 +117,7 @@ class PyBadger:
         # Count is hardcoded - should be based on board ID, currently no board info for PyBadge LC
         neopixel_count = 5
         self._neopixels = neopixel.NeoPixel(board.NEOPIXEL, neopixel_count,
-                                            pixel_order=neopixel.GRB)
+                                brightness=pixels_brightness, pixel_order=neopixel.GRB)
 
         # Auto dim display based on movement
         self._last_accelerometer = None
@@ -154,7 +155,7 @@ class PyBadger:
                 self.display.brightness = 0.1
                 self._start_time = current_time
         else:
-            self.display.brightness = 1
+            self.display.brightness = self._brightness_value
 
     @property
     def pixels(self):
@@ -206,7 +207,7 @@ class PyBadger:
 
     @property
     def acceleration(self):
-        """Accelerometer data."""
+        """Accelerometer data, +/- 2G sensitivity."""
         return self._accelerometer.acceleration if self._accelerometer is not None else None
 
     @property
@@ -216,6 +217,7 @@ class PyBadger:
 
     @brightness.setter
     def brightness(self, value):
+        self._brightness_value = value
         self.display.brightness = value
 
     # pylint: disable=too-many-locals


### PR DESCRIPTION
1) Add the capability to set pixel brightness when instantiating PyBadger. Use the standard value range for NeoPixels. If omitted, default to brightness value of 1.0. Example: 
```
from adafruit_pybadger import PyBadger
pybadger = PyBadger(pixels_brightness=0.01)
```
2) Use setter value rather than `brightness=1.0` when restoring to initial brightness with `auto_dim_display()`:
```
pybadger.brightness = 0.9  # set initial display brightness
```