### PR TITLE
Temporary deployment fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ deploy:
       condition: $DEPLOY_PYPI = "true"
 
 install:
+  - sudo apt-get install libudev-dev libusb-1.0
   - pip install -r requirements.txt
   - pip install circuitpython-build-tools Sphinx sphinx-rtd-theme
   - pip install --force-reinstall pylint==1.9.2


### PR DESCRIPTION
Options right now are remove blinka requirement or add libusb. Since I wanted to leave the option to run this on Blinka in the future, I opted for adding libusb.