### PR TITLE
Add simulated directional buttons for PyGamer

### DIFF
--- a/adafruit_pybadger.py
+++ b/adafruit_pybadger.py
@@ -206,10 +206,22 @@ class PyBadger:
 
         """
         button_values = self._buttons.get_pressed()
-        return Buttons(*[button_values & button for button in
-                         (PyBadger.BUTTON_B, PyBadger.BUTTON_A, PyBadger.BUTTON_START,
-                          PyBadger.BUTTON_SELECT, PyBadger.BUTTON_RIGHT,
-                          PyBadger.BUTTON_DOWN, PyBadger.BUTTON_UP, PyBadger.BUTTON_LEFT)])
+        if hasattr(board, "JOYSTICK_X"):
+            x, y = self.joystick
+            return Buttons(button_values & PyBadger.BUTTON_B,
+                           button_values & PyBadger.BUTTON_A,
+                           button_values & PyBadger.BUTTON_START,
+                           button_values & PyBadger.BUTTON_SELECT,
+                           x > 50000, # RIGHT
+                           y > 50000, # DOWN
+                           y < 15000, # UP
+                           x < 15000  # LEFT
+                          )
+        else:
+            return Buttons(*[button_values & button for button in
+                             (PyBadger.BUTTON_B, PyBadger.BUTTON_A, PyBadger.BUTTON_START,
+                              PyBadger.BUTTON_SELECT, PyBadger.BUTTON_RIGHT,
+                              PyBadger.BUTTON_DOWN, PyBadger.BUTTON_UP, PyBadger.BUTTON_LEFT)])
 
     @property
     def light(self):

--- a/adafruit_pybadger.py
+++ b/adafruit_pybadger.py
@@ -205,6 +205,7 @@ class PyBadger:
                 print("Button select")
 
         """
+        #pylint: disable=no-else-return
         button_values = self._buttons.get_pressed()
         if hasattr(board, "JOYSTICK_X"):
             x, y = self.joystick


### PR DESCRIPTION
For #15 

Sort of magic numbery, but works.

Below is with joystick centered, then full UP, DOWN, LEFT, RIGHT:
```python
Adafruit CircuitPython 4.1.2 on 2019-12-18; Adafruit PyGamer with samd51j19
>>> from adafruit_pybadger import PyBadger
>>> pygamer = PyBadger()
>>> pygamer.joystick
(35008, 33152)
>>> pygamer.button
Buttons(b=0, a=0, start=0, select=0, right=False, down=False, up=False, left=False)
>>> pygamer.button
Buttons(b=0, a=0, start=0, select=0, right=False, down=False, up=True, left=False)
>>> pygamer.button
Buttons(b=0, a=0, start=0, select=0, right=False, down=True, up=False, left=False)
>>> pygamer.button
Buttons(b=0, a=0, start=0, select=0, right=False, down=False, up=False, left=True)
>>> pygamer.button
Buttons(b=0, a=0, start=0, select=0, right=True, down=False, up=False, left=False)
>>> 
```