### PR TITLE
Fix business card display

### DIFF
--- a/adafruit_pybadger.py
+++ b/adafruit_pybadger.py
@@ -300,24 +300,28 @@ class PyBadger:
             except AttributeError:
                 self.display.wait_for_frame()
 
+        business_card_label_groups = []
         if name_string:
             name_group = self._create_label_group(text=name_string,
                                                   font=name_font,
                                                   scale=name_scale,
                                                   height_adjustment=0.73)
-            business_card_splash.append(name_group)
+            business_card_label_groups.append(name_group)
         if email_string_one:
             email_one_group = self._create_label_group(text=email_string_one,
                                                        font=email_font_one,
                                                        scale=email_scale_one,
                                                        height_adjustment=0.84)
-            business_card_splash.append(email_one_group)
+            business_card_label_groups.append(email_one_group)
         if email_string_two:
             email_two_group = self._create_label_group(text=email_string_two,
                                                        font=email_font_two,
                                                        scale=email_scale_two,
                                                        height_adjustment=0.91)
-            business_card_splash.append(email_two_group)
+            business_card_label_groups.append(email_two_group)
+
+        for group in business_card_label_groups:
+            business_card_splash.append(group)
 
     # pylint: disable=too-many-locals
     def show_badge(self, *, background_color=0xFF0000, foreground_color=0xFFFFFF,

--- a/adafruit_pybadger.py
+++ b/adafruit_pybadger.py
@@ -295,10 +295,7 @@ class PyBadger:
             on_disk_bitmap = displayio.OnDiskBitmap(file_name)
             face_image = displayio.TileGrid(on_disk_bitmap, pixel_shader=displayio.ColorConverter())
             business_card_splash.append(face_image)
-            try:
-                self.display.refresh(target_frames_per_second=60)
-            except AttributeError:
-                self.display.wait_for_frame()
+            self.display.refresh()
 
         business_card_label_groups = []
         if name_string:

--- a/adafruit_pybadger.py
+++ b/adafruit_pybadger.py
@@ -289,14 +289,6 @@ class PyBadger:
                                ``terminalio.FONT``.
 
         """
-        business_card_splash = displayio.Group(max_size=4)
-        self.display.show(business_card_splash)
-        with open(image_name, "rb") as file_name:
-            on_disk_bitmap = displayio.OnDiskBitmap(file_name)
-            face_image = displayio.TileGrid(on_disk_bitmap, pixel_shader=displayio.ColorConverter())
-            business_card_splash.append(face_image)
-            self.display.refresh()
-
         business_card_label_groups = []
         if name_string:
             name_group = self._create_label_group(text=name_string,
@@ -317,8 +309,15 @@ class PyBadger:
                                                        height_adjustment=0.91)
             business_card_label_groups.append(email_two_group)
 
-        for group in business_card_label_groups:
-            business_card_splash.append(group)
+        business_card_splash = displayio.Group(max_size=4)
+        self.display.show(business_card_splash)
+        with open(image_name, "rb") as file_name:
+            on_disk_bitmap = displayio.OnDiskBitmap(file_name)
+            face_image = displayio.TileGrid(on_disk_bitmap, pixel_shader=displayio.ColorConverter())
+            business_card_splash.append(face_image)
+            for group in business_card_label_groups:
+                business_card_splash.append(group)
+            self.display.refresh()
 
     # pylint: disable=too-many-locals
     def show_badge(self, *, background_color=0xFF0000, foreground_color=0xFFFFFF,

--- a/adafruit_pybadger.py
+++ b/adafruit_pybadger.py
@@ -289,7 +289,7 @@ class PyBadger:
                                ``terminalio.FONT``.
 
         """
-        business_card_splash = displayio.Group(max_size=30)
+        business_card_splash = displayio.Group(max_size=4)
         self.display.show(business_card_splash)
         with open(image_name, "rb") as file_name:
             on_disk_bitmap = displayio.OnDiskBitmap(file_name)

--- a/adafruit_pybadger.py
+++ b/adafruit_pybadger.py
@@ -317,7 +317,12 @@ class PyBadger:
             business_card_splash.append(face_image)
             for group in business_card_label_groups:
                 business_card_splash.append(group)
-            self.display.refresh()
+            try:
+                # Refresh display in CircuitPython 5
+                self.display.refresh()
+            except AttributeError:
+                # Refresh display in CircuitPython 4
+                self.display.wait_for_frame()
 
     # pylint: disable=too-many-locals
     def show_badge(self, *, background_color=0xFF0000, foreground_color=0xFFFFFF,


### PR DESCRIPTION
I noticed strange behavior when using the business card function in this library.

The text would display, then hide, then display again. Additionally, the image elements wouldn't appear at the same time.

It looked like this:
![circuitpy_before](https://user-images.githubusercontent.com/2030983/74574722-684f9e80-4f39-11ea-9fe7-35e98e5d7108.gif)

I made some updates to make the text appear smoothly with the background. It now looks like this:

![circuit_py_after](https://user-images.githubusercontent.com/2030983/74574601-1575e700-4f39-11ea-81bb-99db0c1b5831.gif)

Notes:
- I removed the call to `wait_for_frame()`, since the release notes for CircuitPython 5.0.0 Alpha 2 say it's no longer necessary.
- Removed the `target_frames_per_second` argument to `refresh`, since that's the default value.

As a side effect, the text displayed no longer has a black background. That might have been a bug in the original code, since I couldn't find a background color property on `adafruit_display_text.label`. 

Tested on a PyBadge LC.