### PR TITLE
Refactor to include CLUE

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Introduction
     :target: https://github.com/adafruit/Adafruit_CircuitPython_PyBadger/actions/
     :alt: Build Status
 
-Badge-focused CircuitPython helper library for PyBadge and PyGamer.
+Badge-focused CircuitPython helper library for PyBadge, PyBadge LC, PyGamer and CLUE.
 
 
 Dependencies
@@ -28,9 +28,6 @@ This is easily achieved by downloading
 
 Installing from PyPI
 =====================
-.. note:: This library is not available on PyPI yet. Install documentation is included
-   as a standard element. Stay tuned for PyPI availability!
-
 On supported GNU/Linux systems like the Raspberry Pi, you can install the driver locally `from
 PyPI <https://pypi.org/project/adafruit-circuitpython-pybadger/>`_. To install for current user:
 
@@ -58,9 +55,7 @@ Usage Example
 
 .. code-block:: python
 
-    from adafruit_pybadger import PyBadger
-
-    pybadger = PyBadger()
+    from adafruit_pybadger import pybadger
 
     pybadger.show_badge(name_string="Blinka", hello_scale=2, my_name_is_scale=2, name_scale=3)
 

--- a/adafruit_pybadger/__init__.py
+++ b/adafruit_pybadger/__init__.py
@@ -1,0 +1,33 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2020 Kattni Rembor for Adafruit Industries
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+Verifies which board is being used and imports the appropriate module.
+"""
+
+import os
+
+if "CLUE" in os.uname().machine:
+    from .clue import clue as pybadger
+elif "Pybadge" in os.uname().machine:
+    from .pybadge import pybadge as pybadger
+elif "PyGamer" in os.uname().machine:
+    from .pygamer import pygamer as pybadger

--- a/adafruit_pybadger/clue.py
+++ b/adafruit_pybadger/clue.py
@@ -79,15 +79,15 @@ class Clue(PyBadgerBase):
 
         .. code-block:: python
 
-        from adafruit_pybadger import PyBadger
+          from adafruit_pybadger import PyBadger
 
-        pybadger = PyBadger()
+          pybadger = PyBadger()
 
-        while True:
-            if pybadger.button.a:
-                print("Button A")
-            elif pybadger.button.b:
-                print("Button B")
+          while True:
+              if pybadger.button.a:
+                  print("Button A")
+              elif pybadger.button.b:
+                  print("Button B")
         """
         button_values = self._buttons.get_pressed()
         return Buttons(button_values & PyBadgerBase.BUTTON_B,

--- a/adafruit_pybadger/clue.py
+++ b/adafruit_pybadger/clue.py
@@ -79,9 +79,7 @@ class Clue(PyBadgerBase):
 
         .. code-block:: python
 
-          from adafruit_pybadger import PyBadger
-
-          pybadger = PyBadger()
+          from adafruit_pybadger import pybadger
 
           while True:
               if pybadger.button.a:

--- a/adafruit_pybadger/clue.py
+++ b/adafruit_pybadger/clue.py
@@ -44,8 +44,8 @@ Implementation Notes
 
 from collections import namedtuple
 import board
-import audiopwmio
 import digitalio
+import audiopwmio
 from gamepad import GamePad
 import adafruit_lsm6ds
 from adafruit_pybadger.pybadger_base import PyBadgerBase
@@ -56,7 +56,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_PyBadger.git"
 Buttons = namedtuple("Buttons", "a b")
 
 class Clue(PyBadgerBase):
-
+    """Class that represents a single CLUE."""
     _audio_out = audiopwmio.PWMAudioOut
     _neopixel_count = 1
 
@@ -73,6 +73,22 @@ class Clue(PyBadgerBase):
 
     @property
     def button(self):
+        """The buttons on the board.
+
+        Example use:
+
+        .. code-block:: python
+
+        from adafruit_pybadger import PyBadger
+
+        pybadger = PyBadger()
+
+        while True:
+            if pybadger.button.a:
+                print("Button A")
+            elif pybadger.button.b:
+                print("Button B")
+        """
         button_values = self._buttons.get_pressed()
         return Buttons(button_values & PyBadgerBase.BUTTON_B,
                        button_values & PyBadgerBase.BUTTON_A)
@@ -80,14 +96,14 @@ class Clue(PyBadgerBase):
 
     @property
     def _unsupported(self):
-        """This feature is not supported on Circuit Playground Express."""
+        """This feature is not supported on CLUE."""
         raise NotImplementedError("This feature is not supported on CLUE.")
 
-    # The following is a list of the features available in other Circuit Playground modules but
-    # not available for Circuit Playground Express. If called while using a Circuit Playground
-    # Express, they will result in the NotImplementedError raised in the property above.
+    # The following is a list of the features available in other PyBadger modules but
+    # not available for CLUE. If called while using a CLUE, they will result in the
+    # NotImplementedError raised in the property above.
     play_file = _unsupported
     light = _unsupported
 
-clue = Clue()
+clue = Clue()  # pylint: disable=invalid-name
 """Object that is automatically created on import."""

--- a/adafruit_pybadger/clue.py
+++ b/adafruit_pybadger/clue.py
@@ -1,0 +1,93 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2020 Kattni Rembor for Adafruit Industries
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+`adafruit_pybadger.clue`
+================================================================================
+
+Badge-focused CircuitPython helper library for CLUE.
+
+
+* Author(s): Kattni Rembor
+
+Implementation Notes
+--------------------
+
+**Hardware:**
+
+* `Adafruit CLUE <https://www.adafruit.com/product/4500>`_
+
+**Software and Dependencies:**
+
+* Adafruit CircuitPython firmware for the supported boards:
+  https://github.com/adafruit/circuitpython/releases
+
+"""
+
+from collections import namedtuple
+import board
+import audiopwmio
+import digitalio
+from gamepad import GamePad
+import adafruit_lsm6ds
+from adafruit_pybadger.pybadger_base import PyBadgerBase
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_PyBadger.git"
+
+Buttons = namedtuple("Buttons", "a b")
+
+class Clue(PyBadgerBase):
+
+    _audio_out = audiopwmio.PWMAudioOut
+    _neopixel_count = 1
+
+    def __init__(self):
+        super().__init__()
+
+        i2c = board.I2C()
+
+        if i2c is not None:
+            self._accelerometer = adafruit_lsm6ds.LSM6DS33(i2c)
+
+        self._buttons = GamePad(digitalio.DigitalInOut(board.BUTTON_A),
+                                digitalio.DigitalInOut(board.BUTTON_B))
+
+    @property
+    def button(self):
+        button_values = self._buttons.get_pressed()
+        return Buttons(button_values & PyBadgerBase.BUTTON_B,
+                       button_values & PyBadgerBase.BUTTON_A)
+
+
+    @property
+    def _unsupported(self):
+        """This feature is not supported on Circuit Playground Express."""
+        raise NotImplementedError("This feature is not supported on CLUE.")
+
+    # The following is a list of the features available in other Circuit Playground modules but
+    # not available for Circuit Playground Express. If called while using a Circuit Playground
+    # Express, they will result in the NotImplementedError raised in the property above.
+    play_file = _unsupported
+    light = _unsupported
+
+clue = Clue()
+"""Object that is automatically created on import."""

--- a/adafruit_pybadger/pybadge.py
+++ b/adafruit_pybadger/pybadge.py
@@ -1,0 +1,124 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2020 Kattni Rembor for Adafruit Industries
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+`adafruit_pybadger.pybadge`
+================================================================================
+
+Badge-focused CircuitPython helper library for PyBadge and PyBadge LC.
+Both boards are included in this module as there is no difference in the
+CircuitPython builds at this time, and therefore no way to differentiate
+the boards from within CircuitPython.
+
+
+* Author(s): Kattni Rembor
+
+Implementation Notes
+--------------------
+
+**Hardware:**
+
+* `Adafruit PyBadge <https://www.adafruit.com/product/4200>`_
+* `Adafruit PyBadge LC <https://www.adafruit.com/product/3939>`_
+
+**Software and Dependencies:**
+
+* Adafruit CircuitPython firmware for the supported boards:
+  https://github.com/adafruit/circuitpython/releases
+
+"""
+
+from collections import namedtuple
+import audioio
+import board
+import digitalio
+import analogio
+from gamepadshift import GamePadShift
+import adafruit_lis3dh
+from adafruit_pybadger.pybadger_base import PyBadgerBase
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_PyBadger.git"
+
+Buttons = namedtuple("Buttons", "b a start select right down up left")
+
+class PyBadge(PyBadgerBase):
+    _audio_out = audioio.AudioOut
+
+    _neopixel_count = 5
+
+
+    def __init__(self):
+        super().__init__()
+
+        i2c = None
+
+        if i2c is None:
+            try:
+                i2c = board.I2C()
+            except RuntimeError:
+                self._accelerometer = None
+
+        if i2c is not None:
+            int1 = digitalio.DigitalInOut(board.ACCELEROMETER_INTERRUPT)
+            try:
+                self._accelerometer = adafruit_lis3dh.LIS3DH_I2C(i2c, address=0x19, int1=int1)
+            except ValueError:
+                self._accelerometer = adafruit_lis3dh.LIS3DH_I2C(i2c, int1=int1)
+
+        self._buttons = GamePadShift(digitalio.DigitalInOut(board.BUTTON_CLOCK),
+                                     digitalio.DigitalInOut(board.BUTTON_OUT),
+                                     digitalio.DigitalInOut(board.BUTTON_LATCH))
+
+        self._light_sensor = analogio.AnalogIn(board.A7)
+
+    @property
+    def button(self):
+        """The buttons on the board.
+
+        Example use:
+
+        .. code-block:: python
+
+        from adafruit_pybadger import PyBadger
+
+        pybadger = PyBadger()
+
+        while True:
+            if pybadger.button.a:
+                print("Button A")
+            elif pybadger.button.b:
+                print("Button B")
+            elif pybadger.button.start:
+                print("Button start")
+            elif pybadger.button.select:
+                print("Button select")
+
+        """
+        button_values = self._buttons.get_pressed()
+        return Buttons(*[button_values & button for button in
+                         (PyBadgerBase.BUTTON_B, PyBadgerBase.BUTTON_A,
+                          PyBadgerBase.BUTTON_START, PyBadgerBase.BUTTON_SELECT,
+                          PyBadgerBase.BUTTON_RIGHT, PyBadgerBase.BUTTON_DOWN,
+                          PyBadgerBase.BUTTON_UP, PyBadgerBase.BUTTON_LEFT)])
+
+pybadge = PyBadge()
+"""Object that is automatically created on import."""

--- a/adafruit_pybadger/pybadge.py
+++ b/adafruit_pybadger/pybadge.py
@@ -99,19 +99,19 @@ class PyBadge(PyBadgerBase):
 
         .. code-block:: python
 
-        from adafruit_pybadger import PyBadger
+          from adafruit_pybadger import PyBadger
 
-        pybadger = PyBadger()
+          pybadger = PyBadger()
 
-        while True:
-            if pybadger.button.a:
-                print("Button A")
-            elif pybadger.button.b:
-                print("Button B")
-            elif pybadger.button.start:
-                print("Button start")
-            elif pybadger.button.select:
-                print("Button select")
+          while True:
+              if pybadger.button.a:
+                  print("Button A")
+              elif pybadger.button.b:
+                  print("Button B")
+              elif pybadger.button.start:
+                  print("Button start")
+              elif pybadger.button.select:
+                  print("Button select")
 
         """
         button_values = self._buttons.get_pressed()

--- a/adafruit_pybadger/pybadge.py
+++ b/adafruit_pybadger/pybadge.py
@@ -23,8 +23,8 @@
 `adafruit_pybadger.pybadge`
 ================================================================================
 
-Badge-focused CircuitPython helper library for PyBadge and PyBadge LC.
-Both boards are included in this module as there is no difference in the
+Badge-focused CircuitPython helper library for PyBadge, PyBadge LC and EdgeBadge.
+All three boards are included in this module as there is no difference in the
 CircuitPython builds at this time, and therefore no way to differentiate
 the boards from within CircuitPython.
 
@@ -38,6 +38,7 @@ Implementation Notes
 
 * `Adafruit PyBadge <https://www.adafruit.com/product/4200>`_
 * `Adafruit PyBadge LC <https://www.adafruit.com/product/3939>`_
+* `Adafruit EdgeBadge <https://www.adafruit.com/product/4400>`_
 
 **Software and Dependencies:**
 
@@ -47,10 +48,10 @@ Implementation Notes
 """
 
 from collections import namedtuple
-import audioio
 import board
 import digitalio
 import analogio
+import audioio
 from gamepadshift import GamePadShift
 import adafruit_lis3dh
 from adafruit_pybadger.pybadger_base import PyBadgerBase
@@ -61,10 +62,10 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_PyBadger.git"
 Buttons = namedtuple("Buttons", "b a start select right down up left")
 
 class PyBadge(PyBadgerBase):
+    """Class that represents a single PyBadge, PyBadge LC, or EdgeBadge."""
+
     _audio_out = audioio.AudioOut
-
     _neopixel_count = 5
-
 
     def __init__(self):
         super().__init__()
@@ -120,5 +121,5 @@ class PyBadge(PyBadgerBase):
                           PyBadgerBase.BUTTON_RIGHT, PyBadgerBase.BUTTON_DOWN,
                           PyBadgerBase.BUTTON_UP, PyBadgerBase.BUTTON_LEFT)])
 
-pybadge = PyBadge()
+pybadge = PyBadge()  # pylint: disable=invalid-name
 """Object that is automatically created on import."""

--- a/adafruit_pybadger/pybadge.py
+++ b/adafruit_pybadger/pybadge.py
@@ -99,9 +99,7 @@ class PyBadge(PyBadgerBase):
 
         .. code-block:: python
 
-          from adafruit_pybadger import PyBadger
-
-          pybadger = PyBadger()
+          from adafruit_pybadger import pybadger
 
           while True:
               if pybadger.button.a:

--- a/adafruit_pybadger/pybadger_base.py
+++ b/adafruit_pybadger/pybadger_base.py
@@ -20,10 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 """
-`adafruit_pybadger`
+`adafruit_pybadger.pybadger_base`
 ================================================================================
 
-Badge-focused CircuitPython helper library for PyBadge and PyGamer.
+Base class for badge-focused CircuitPython helper library.
 
 
 * Author(s): Kattni Rembor
@@ -33,6 +33,7 @@ Implementation Notes
 
 **Hardware:**
 
+* `Adafruit CLUE <https://www.adafruit.com/product/4500>`_
 * `Adafruit PyBadge <https://www.adafruit.com/product/4200>`_
 * `Adafruit PyBadge LC <https://www.adafruit.com/product/3939>`_
 * `Adafruit PyGamer <https://www.adafruit.com/product/4277>`_

--- a/adafruit_pybadger/pybadger_base.py
+++ b/adafruit_pybadger/pybadger_base.py
@@ -335,7 +335,6 @@ class PyBadgerBase:
         """Generate a QR code and display it for ``dwell`` seconds.
 
         :param string data: A string of data for the QR code
-        :param int dwell: The amount of time in seconds to display the QR code
 
         """
         qr_code = adafruit_miniqr.QRCode(qr_type=3, error_correct=adafruit_miniqr.L)
@@ -402,7 +401,6 @@ class PyBadgerBase:
 
     def stop_tone(self):
         """ Use with start_tone to stop the tone produced.
-
         """
         # Stop playing any tones.
         if self._sample is not None and self._sample.playing:

--- a/adafruit_pybadger/pybadger_base.py
+++ b/adafruit_pybadger/pybadger_base.py
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2019 Kattni Rembor for Adafruit Industries
+# Copyright (c) 2019-2020 Kattni Rembor for Adafruit Industries
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -47,15 +47,13 @@ Implementation Notes
 import time
 import array
 import math
-from collections import namedtuple
 import board
 from micropython import const
 import digitalio
-import analogio
 try:
-    import audioio
+    import audiocore
 except ImportError:
-    import audiocore as audioio
+    import audioio as audiocore
 import displayio
 import neopixel
 from adafruit_display_shapes.rect import Rect
@@ -63,17 +61,9 @@ from adafruit_display_text.label import Label
 from adafruit_bitmap_font import bitmap_font
 import terminalio
 import adafruit_miniqr
-import adafruit_lis3dh
-
-import adafruit_lsm6ds
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_PyBadger.git"
-
-if hasattr(board, "BUTTON_SELECT"):
-    Buttons = namedtuple("Buttons", "b a start select right down up left")
-else:
-    Buttons = namedtuple("Buttons", "b a")
 
 def load_font(fontname, text):
     """Load a font and glyphs in the text string
@@ -87,8 +77,12 @@ def load_font(fontname, text):
     return font
 
 # pylint: disable=too-many-instance-attributes
-class PyBadger:
-    """PyBadger class."""
+class PyBadgerBase:
+    """PyBadger base class."""
+
+    _audio_out = None
+    _neopixel_count = None
+
     # Button Constants
     BUTTON_LEFT = const(128)
     BUTTON_UP = const(64)
@@ -99,52 +93,16 @@ class PyBadger:
     BUTTON_A = const(2)
     BUTTON_B = const(1)
 
-    def __init__(self, i2c=None, *, pixels_brightness=1.0):
-        # Accelerometer
-        if i2c is None:
-            try:
-                i2c = board.I2C()
-            except RuntimeError:
-                self._accelerometer = None
-
-        if hasattr(board, "ACCELEROMETER_INTERRUPT"):
-            if i2c is not None:
-                int1 = digitalio.DigitalInOut(board.ACCELEROMETER_INTERRUPT)
-                try:
-                    self._accelerometer = adafruit_lis3dh.LIS3DH_I2C(i2c, address=0x19, int1=int1)
-                except ValueError:
-                    self._accelerometer = adafruit_lis3dh.LIS3DH_I2C(i2c, int1=int1)
-        else:
-            if i2c is not None:
-                self._accelerometer = adafruit_lsm6ds.LSM6DS33(i2c)
-
-        # Buttons
-        try:
-            from gamepadshift import GamePadShift
-            self._buttons = GamePadShift(digitalio.DigitalInOut(board.BUTTON_CLOCK),
-                                         digitalio.DigitalInOut(board.BUTTON_OUT),
-                                         digitalio.DigitalInOut(board.BUTTON_LATCH))
-        except ImportError:
-            from gamepad import GamePad
-            self._buttons = GamePad(digitalio.DigitalInOut(board.BUTTON_A),
-                                    digitalio.DigitalInOut(board.BUTTON_B))
+    def __init__(self, *, pixels_brightness=1.0):
+        self._light_sensor = None
+        self._accelerometer = None
 
         # Display
         self.display = board.DISPLAY
         self._display_brightness = 1.0
 
-        # Light sensor
-        self._light_sensor = analogio.AnalogIn(board.A7)
-
-        # PyGamer joystick
-        if hasattr(board, "JOYSTICK_X"):
-            self._pygamer_joystick_x = analogio.AnalogIn(board.JOYSTICK_X)
-            self._pygamer_joystick_y = analogio.AnalogIn(board.JOYSTICK_Y)
-
         # NeoPixels
-        # Count is hardcoded - should be based on board ID, currently no board info for PyBadge LC
-        neopixel_count = 5
-        self._neopixels = neopixel.NeoPixel(board.NEOPIXEL, neopixel_count,
+        self._neopixels = neopixel.NeoPixel(board.NEOPIXEL, self._neopixel_count,
                                             brightness=pixels_brightness, pixel_order=neopixel.GRB)
 
         # Auto dim display based on movement
@@ -155,8 +113,6 @@ class PyBadger:
         if hasattr(board, "SPEAKER_ENABLE"):
             self._speaker_enable = digitalio.DigitalInOut(board.SPEAKER_ENABLE)
             self._speaker_enable.switch_to_output(value=False)
-        else:
-            self._speaker_enable = None
         self._sample = None
         self._sine_wave = None
         self._sine_wave_sample = None
@@ -210,60 +166,6 @@ class PyBadger:
     def pixels(self):
         """Sequence like object representing the NeoPixels on the board."""
         return self._neopixels
-
-    @property
-    def joystick(self):
-        """The joystick on the PyGamer."""
-        if hasattr(board, "JOYSTICK_X"):
-            x = self._pygamer_joystick_x.value
-            y = self._pygamer_joystick_y.value
-            return x, y
-        raise RuntimeError("This board does not have a built in joystick.")
-
-    @property
-    def button(self):
-        """The buttons on the board.
-
-        Example use:
-
-        .. code-block:: python
-
-        from adafruit_pybadger import PyBadger
-
-        pybadger = PyBadger()
-
-        while True:
-            if pybadger.button.a:
-                print("Button A")
-            elif pybadger.button.b:
-                print("Button B")
-            elif pybadger.button.start:
-                print("Button start")
-            elif pybadger.button.select:
-                print("Button select")
-
-        """
-        #pylint: disable=no-else-return
-        button_values = self._buttons.get_pressed()
-        if hasattr(board, "JOYSTICK_X"):
-            x, y = self.joystick
-            return Buttons(button_values & PyBadger.BUTTON_B,
-                           button_values & PyBadger.BUTTON_A,
-                           button_values & PyBadger.BUTTON_START,
-                           button_values & PyBadger.BUTTON_SELECT,
-                           x > 50000, # RIGHT
-                           y > 50000, # DOWN
-                           y < 15000, # UP
-                           x < 15000  # LEFT
-                          )
-        elif hasattr(board, "WHITE_LEDS"):
-            return Buttons(button_values & PyBadger.BUTTON_B,
-                           button_values & PyBadger.BUTTON_A)
-        else:
-            return Buttons(*[button_values & button for button in
-                             (PyBadger.BUTTON_B, PyBadger.BUTTON_A, PyBadger.BUTTON_START,
-                              PyBadger.BUTTON_SELECT, PyBadger.BUTTON_RIGHT,
-                              PyBadger.BUTTON_DOWN, PyBadger.BUTTON_UP, PyBadger.BUTTON_LEFT)])
 
     @property
     def light(self):
@@ -463,9 +365,9 @@ class PyBadger:
     def _generate_sample(self, length=100):
         if self._sample is not None:
             return
-        self._sine_wave = array.array("H", PyBadger._sine_sample(length))
-        self._sample = audioio.AudioOut(board.SPEAKER)
-        self._sine_wave_sample = audioio.RawSample(self._sine_wave)
+        self._sine_wave = array.array("H", PyBadgerBase._sine_sample(length))
+        self._sample = self._audio_out(board.SPEAKER)  # pylint: disable=not-callable
+        self._sine_wave_sample = audiocore.RawSample(self._sine_wave)
 
     def play_tone(self, frequency, duration):
         """ Produce a tone using the speaker. Try changing frequency to change
@@ -487,7 +389,8 @@ class PyBadger:
         :param int frequency: The frequency of the tone in Hz
 
         """
-        self._speaker_enable.value = True
+        if hasattr(board, "SPEAKER_ENABLE"):
+            self._speaker_enable.value = True
         length = 100
         if length * frequency > 350000:
             length = 350000 // frequency
@@ -506,7 +409,8 @@ class PyBadger:
             self._sample.stop()
             self._sample.deinit()
             self._sample = None
-        self._speaker_enable.value = False
+        if hasattr(board, "SPEAKER_ENABLE"):
+            self._speaker_enable.value = False
 
     def play_file(self, file_name):
         """ Play a .wav file using the onboard speaker.
@@ -516,12 +420,12 @@ class PyBadger:
         """
         # Play a specified file.
         self.stop_tone()
-        self._speaker_enable.value = True
-        with audioio.AudioOut(board.SPEAKER) as audio:
-            wavefile = audioio.WaveFile(open(file_name, "rb"))
+        if hasattr(board, "SPEAKER_ENABLE"):
+            self._speaker_enable.value = True
+        with self._audio_out(board.SPEAKER) as audio:  # pylint: disable=not-callable
+            wavefile = audiocore.WaveFile(open(file_name, "rb"))
             audio.play(wavefile)
             while audio.playing:
                 pass
-        self._speaker_enable.value = False
-
-pybadger = PyBadger()
+        if hasattr(board, "SPEAKER_ENABLE"):
+            self._speaker_enable.value = False

--- a/adafruit_pybadger/pybadger_base.py
+++ b/adafruit_pybadger/pybadger_base.py
@@ -374,6 +374,11 @@ class PyBadgerBase:
         self._sample = self._audio_out(board.SPEAKER)  # pylint: disable=not-callable
         self._sine_wave_sample = audiocore.RawSample(self._sine_wave)
 
+    def _enable_speaker(self, enable):
+        if not hasattr(board, "SPEAKER_ENABLE"):
+            return
+        self._speaker_enable.value = enable
+
     def play_tone(self, frequency, duration):
         """ Produce a tone using the speaker. Try changing frequency to change
         the pitch of the tone.
@@ -394,8 +399,7 @@ class PyBadgerBase:
         :param int frequency: The frequency of the tone in Hz
 
         """
-        if hasattr(board, "SPEAKER_ENABLE"):
-            self._speaker_enable.value = True
+        self._enable_speaker(enable=True)
         length = 100
         if length * frequency > 350000:
             length = 350000 // frequency
@@ -413,8 +417,7 @@ class PyBadgerBase:
             self._sample.stop()
             self._sample.deinit()
             self._sample = None
-        if hasattr(board, "SPEAKER_ENABLE"):
-            self._speaker_enable.value = False
+        self._enable_speaker(enable=False)
 
     def play_file(self, file_name):
         """ Play a .wav file using the onboard speaker.
@@ -424,12 +427,10 @@ class PyBadgerBase:
         """
         # Play a specified file.
         self.stop_tone()
-        if hasattr(board, "SPEAKER_ENABLE"):
-            self._speaker_enable.value = True
+        self._enable_speaker(enable=True)
         with self._audio_out(board.SPEAKER) as audio:  # pylint: disable=not-callable
             wavefile = audiocore.WaveFile(open(file_name, "rb"))
             audio.play(wavefile)
             while audio.playing:
                 pass
-        if hasattr(board, "SPEAKER_ENABLE"):
-            self._speaker_enable.value = False
+        self._enable_speaker(enable=True)

--- a/adafruit_pybadger/pygamer.py
+++ b/adafruit_pybadger/pygamer.py
@@ -54,7 +54,7 @@ from adafruit_pybadger.pybadger_base import PyBadgerBase
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_PyBadger.git"
 
-Buttons = namedtuple("Buttons", "b a start select")
+Buttons = namedtuple("Buttons", "b a start select right down up left")
 
 class PyGamer(PyBadgerBase):
     """Class that represents a single PyGamer."""
@@ -90,9 +90,7 @@ class PyGamer(PyBadgerBase):
 
         .. code-block:: python
 
-          from adafruit_pybadger import PyBadger
-
-          pybadger = PyBadger()
+          from adafruit_pybadger import pybadger
 
           while True:
               if pybadger.button.a:
@@ -110,6 +108,10 @@ class PyGamer(PyBadgerBase):
                        button_values & PyBadgerBase.BUTTON_A,
                        button_values & PyBadgerBase.BUTTON_START,
                        button_values & PyBadgerBase.BUTTON_SELECT,
+                       x > 50000,  # RIGHT
+                       y > 50000,  # DOWN
+                       y < 15000,  # UP
+                       x < 15000  # LEFT
                       )
 
     @property

--- a/adafruit_pybadger/pygamer.py
+++ b/adafruit_pybadger/pygamer.py
@@ -43,10 +43,10 @@ Implementation Notes
 """
 
 from collections import namedtuple
-import audioio
 import board
 import analogio
 import digitalio
+import audioio
 from gamepadshift import GamePadShift
 import adafruit_lis3dh
 from adafruit_pybadger.pybadger_base import PyBadgerBase
@@ -57,8 +57,11 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_PyBadger.git"
 Buttons = namedtuple("Buttons", "b a start select")
 
 class PyGamer(PyBadgerBase):
+    """Class that represents a single PyGamer."""
+
     _audio_out = audioio.AudioOut
     _neopixel_count = 5
+
     def __init__(self):
         super().__init__()
 
@@ -116,5 +119,5 @@ class PyGamer(PyBadgerBase):
         y = self._pygamer_joystick_y.value
         return x, y
 
-pygamer = PyGamer()
+pygamer = PyGamer()  # pylint: disable=invalid-name
 """Object that is automatically created on import."""

--- a/adafruit_pybadger/pygamer.py
+++ b/adafruit_pybadger/pygamer.py
@@ -90,19 +90,19 @@ class PyGamer(PyBadgerBase):
 
         .. code-block:: python
 
-        from adafruit_pybadger import PyBadger
+          from adafruit_pybadger import PyBadger
 
-        pybadger = PyBadger()
+          pybadger = PyBadger()
 
-        while True:
-            if pybadger.button.a:
-                print("Button A")
-            elif pybadger.button.b:
-                print("Button B")
-            elif pybadger.button.start:
-                print("Button start")
-            elif pybadger.button.select:
-                print("Button select")
+          while True:
+              if pybadger.button.a:
+                  print("Button A")
+              elif pybadger.button.b:
+                  print("Button B")
+              elif pybadger.button.start:
+                  print("Button start")
+              elif pybadger.button.select:
+                  print("Button select")
 
         """
         button_values = self._buttons.get_pressed()

--- a/adafruit_pybadger/pygamer.py
+++ b/adafruit_pybadger/pygamer.py
@@ -1,0 +1,120 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2020 Kattni Rembor for Adafruit Industries
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+`adafruit_pybadger.pygamer`
+================================================================================
+
+Badge-focused CircuitPython helper library for PyGamer.
+
+
+* Author(s): Kattni Rembor
+
+Implementation Notes
+--------------------
+
+**Hardware:**
+
+* `Adafruit PyGamer <https://www.adafruit.com/product/4277>`_
+
+**Software and Dependencies:**
+
+* Adafruit CircuitPython firmware for the supported boards:
+  https://github.com/adafruit/circuitpython/releases
+
+"""
+
+from collections import namedtuple
+import audioio
+import board
+import analogio
+import digitalio
+from gamepadshift import GamePadShift
+import adafruit_lis3dh
+from adafruit_pybadger.pybadger_base import PyBadgerBase
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_PyBadger.git"
+
+Buttons = namedtuple("Buttons", "b a start select")
+
+class PyGamer(PyBadgerBase):
+    _audio_out = audioio.AudioOut
+    _neopixel_count = 5
+    def __init__(self):
+        super().__init__()
+
+        i2c = board.I2C()
+
+        int1 = digitalio.DigitalInOut(board.ACCELEROMETER_INTERRUPT)
+        try:
+            self._accelerometer = adafruit_lis3dh.LIS3DH_I2C(i2c, address=0x19, int1=int1)
+        except ValueError:
+            self._accelerometer = adafruit_lis3dh.LIS3DH_I2C(i2c, int1=int1)
+
+        self._buttons = GamePadShift(digitalio.DigitalInOut(board.BUTTON_CLOCK),
+                                     digitalio.DigitalInOut(board.BUTTON_OUT),
+                                     digitalio.DigitalInOut(board.BUTTON_LATCH))
+
+        self._pygamer_joystick_x = analogio.AnalogIn(board.JOYSTICK_X)
+        self._pygamer_joystick_y = analogio.AnalogIn(board.JOYSTICK_Y)
+
+        self._light_sensor = analogio.AnalogIn(board.A7)
+
+    @property
+    def button(self):
+        """The buttons on the board.
+
+        Example use:
+
+        .. code-block:: python
+
+        from adafruit_pybadger import PyBadger
+
+        pybadger = PyBadger()
+
+        while True:
+            if pybadger.button.a:
+                print("Button A")
+            elif pybadger.button.b:
+                print("Button B")
+            elif pybadger.button.start:
+                print("Button start")
+            elif pybadger.button.select:
+                print("Button select")
+
+        """
+        button_values = self._buttons.get_pressed()
+        return Buttons(button_values & PyBadgerBase.BUTTON_B,
+                       button_values & PyBadgerBase.BUTTON_A,
+                       button_values & PyBadgerBase.BUTTON_START,
+                       button_values & PyBadgerBase.BUTTON_SELECT,
+                      )
+
+    @property
+    def joystick(self):
+        """The joystick on the PyGamer."""
+        x = self._pygamer_joystick_x.value
+        y = self._pygamer_joystick_y.value
+        return x, y
+
+pygamer = PyGamer()
+"""Object that is automatically created on import."""

--- a/adafruit_pybadger/pygamer.py
+++ b/adafruit_pybadger/pygamer.py
@@ -104,6 +104,7 @@ class PyGamer(PyBadgerBase):
 
         """
         button_values = self._buttons.get_pressed()
+        x, y = self.joystick
         return Buttons(button_values & PyBadgerBase.BUTTON_B,
                        button_values & PyBadgerBase.BUTTON_A,
                        button_values & PyBadgerBase.BUTTON_START,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,5 +4,14 @@
 .. If your library file(s) are nested in a directory (e.g. /adafruit_foo/foo.py)
 .. use this format as the module name: "adafruit_foo.foo"
 
-.. automodule:: adafruit_pybadger
+.. automodule:: adafruit_pybadger.pybadger_base
+   :members:
+
+.. automodule:: adafruit_pybadger.clue
+   :members:
+
+.. automodule:: adafruit_pybadger.pybadge
+   :members:
+
+.. automodule:: adafruit_pybadger.pygamer
    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ extensions = [
 autodoc_mock_imports = ["audioio", "displayio", "gamepadshift", "neopixel", "analogio",
                         "adafruit_display_shapes", "adafruit_display_text", "terminalio",
                         "adafruit_miniqr", "adafruit_lis3dh", "adafruit_miniqr",
-                        "adafruit_bitmap_font"]
+                        "adafruit_bitmap_font", "adafruit_lsm6ds"]
 
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3.4', None),'CircuitPython': ('https://circuitpython.readthedocs.io/en/latest/', None)}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,11 +24,7 @@ autodoc_mock_imports = ["audioio", "displayio", "gamepadshift", "neopixel", "ana
                         "adafruit_display_shapes", "adafruit_display_text", "terminalio",
                         "adafruit_miniqr", "adafruit_lis3dh", "adafruit_bitmap_font",
                         "adafruit_lsm6ds", "gamepad", "audiocore", "audiopwmio", "micropython",
-                        "terminalio", "digitalio",
-                        "collections", "board", "time", "array", "math",
-                        "adafruit_pybadger.pybadger_base",
-                        "adafruit_pybadger", "adafruit_pybadger.clue", "adafruit_pybadger.pygamer",
-                        "adafruit_pybadger.pybadge"]
+                        "terminalio", "digitalio", "board"]
 
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3.4', None),'CircuitPython': ('https://circuitpython.readthedocs.io/en/latest/', None)}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,11 @@ autodoc_mock_imports = ["audioio", "displayio", "gamepadshift", "neopixel", "ana
                         "adafruit_display_shapes", "adafruit_display_text", "terminalio",
                         "adafruit_miniqr", "adafruit_lis3dh", "adafruit_bitmap_font",
                         "adafruit_lsm6ds", "gamepad", "audiocore", "audiopwmio", "micropython",
+                        "terminalio", "digitalio",
                         "collections", "board", "time", "array", "math",
-                        "adafruit_pybadger.pybadger_base", "terminalio", "digitalio",
-                        "adafruit_pybadger"]
+                        "adafruit_pybadger.pybadger_base",
+                        "adafruit_pybadger", "adafruit_pybadger.clue", "adafruit_pybadger.pygamer",
+                        "adafruit_pybadger.pybadge"]
 
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3.4', None),'CircuitPython': ('https://circuitpython.readthedocs.io/en/latest/', None)}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,8 @@ extensions = [
 autodoc_mock_imports = ["audioio", "displayio", "gamepadshift", "neopixel", "analogio",
                         "adafruit_display_shapes", "adafruit_display_text", "terminalio",
                         "adafruit_miniqr", "adafruit_lis3dh", "adafruit_miniqr",
-                        "adafruit_bitmap_font", "adafruit_lsm6ds"]
+                        "adafruit_bitmap_font", "adafruit_lsm6ds", "gamepad", "audiocore",
+                        "audiopwmio"]
 
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3.4', None),'CircuitPython': ('https://circuitpython.readthedocs.io/en/latest/', None)}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,9 +22,11 @@ extensions = [
 # autodoc module docs will fail to generate with a warning.
 autodoc_mock_imports = ["audioio", "displayio", "gamepadshift", "neopixel", "analogio",
                         "adafruit_display_shapes", "adafruit_display_text", "terminalio",
-                        "adafruit_miniqr", "adafruit_lis3dh", "adafruit_miniqr",
-                        "adafruit_bitmap_font", "adafruit_lsm6ds", "gamepad", "audiocore",
-                        "audiopwmio"]
+                        "adafruit_miniqr", "adafruit_lis3dh", "adafruit_bitmap_font",
+                        "adafruit_lsm6ds", "gamepad", "audiocore", "audiopwmio", "micropython",
+                        "collections", "board", "time", "array", "math",
+                        "adafruit_pybadger.pybadger_base", "terminalio", "digitalio",
+                        "adafruit_pybadger"]
 
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3.4', None),'CircuitPython': ('https://circuitpython.readthedocs.io/en/latest/', None)}

--- a/examples/pybadger_simpletest.py
+++ b/examples/pybadger_simpletest.py
@@ -1,6 +1,4 @@
-from adafruit_pybadger import PyBadger
-
-pybadger = PyBadger()
+from adafruit_pybadger import pybadger
 
 pybadger.show_badge(name_string="Blinka", hello_scale=2, my_name_is_scale=2, name_scale=3)
 

--- a/setup.py
+++ b/setup.py
@@ -59,5 +59,5 @@ setup(
     # simple. Or you can use find_packages().
     # TODO: IF LIBRARY FILES ARE A PACKAGE FOLDER,
     #       CHANGE `py_modules=['...']` TO `packages=['...']`
-    py_modules=['adafruit_pybadger'],
+    packages=['adafruit_pybadger'],
 )


### PR DESCRIPTION
THIS IS A BREAKING CHANGE. Import is no longer the same and the library no longer requires instantiation. It is now:
```
from adafruit_pybadger import pyadger
```
All code beyond import and instantiation should function the same if library was instantiated as `pybadger`. To use features, simply include them as `pybadger.foo`, e.g.:
```
print(pybadger.acceleration)
pybadger.show_qr_code()
```
Updates:
* No new features have been added.
* Board type is automatically detected and applicable features are imported.
* Features that are not supported on a given board throw a clear error.
 
Tested on PyBadge/LC, PyGamer and CLUE.

@nnja Feel free to test this with your code.