### PR TITLE
adding button debouncing example

### DIFF
--- a/examples/pybadger_button_debouncing.py
+++ b/examples/pybadger_button_debouncing.py
@@ -1,0 +1,47 @@
+from adafruit_debouncer import Debouncer
+from adafruit_pybadger import pybadger
+
+b_btn = Debouncer(lambda: pybadger.button.b == 0)
+a_btn = Debouncer(lambda: pybadger.button.a == 0)
+up_btn = Debouncer(lambda: pybadger.button.up == 0)
+down_btn = Debouncer(lambda: pybadger.button.down == 0)
+left_btn = Debouncer(lambda: pybadger.button.left == 0)
+right_btn = Debouncer(lambda: pybadger.button.right == 0)
+
+while True:
+    b_btn.update()
+    a_btn.update()
+    up_btn.update()
+    down_btn.update()
+    right_btn.update()
+    left_btn.update()
+
+    if b_btn.fell:
+        print("B pressed")
+    if b_btn.rose:
+        print("B released")
+
+    if a_btn.fell:
+        print("A pressed")
+    if a_btn.rose:
+        print("A released")
+
+    if up_btn.fell:
+        print("UP pressed")
+    if up_btn.rose:
+        print("UP released")
+
+    if down_btn.fell:
+        print("DOWN pressed")
+    if down_btn.rose:
+        print("DOWN released")
+
+    if right_btn.fell:
+        print("RIGHT pressed")
+    if right_btn.rose:
+        print("RIGHT released")
+
+    if left_btn.fell:
+        print("LEFT pressed")
+    if left_btn.rose:
+        print("LEFT released")


### PR DESCRIPTION
A few people in the #help-with-circuitpython channel of the discord recently have asked about using the debouncer library with pybadger buttons. 

Since the buttons are not connected directly to digital IO pins it needs to be setup slightly differently. 

This adds an example showing the use of `lambda` to wrap the pybadger button values in a function that can be used with the debouncer library. 