### PR TITLE
Remove usage of max_glyphs with Label

### DIFF
--- a/adafruit_pybadger/pybadger_base.py
+++ b/adafruit_pybadger/pybadger_base.py
@@ -302,9 +302,7 @@ class PyBadgerBase:
         if isinstance(font, str):
             font = load_font(font, text)
 
-        text_label = self._label.Label(
-            font=font, text=text, max_glyphs=45, color=color, scale=scale
-        )
+        text_label = self._label.Label(font=font, text=text, color=color, scale=scale)
         self._lines.append(text_label)
 
         _, _, width, height = text_label.bounding_box


### PR DESCRIPTION
Remove usage of `max_glyphs` now that it has been removed from `Adafruit_CircuitPython_Display_Text`
https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/releases/tag/2.20.0

Tested on a PyPortal with `7.0.0-alpha-5` and `examples/pybadger_pyportal_touchscreen.py`