### PR TITLE
update to show_business_card in pybadger_base.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 *.mpy
 .idea
+.vscode
 __pycache__
 _build
 *.pyc

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.linting.pylintEnabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.linting.pylintEnabled": true
-}

--- a/adafruit_pybadger/pybadger_base.py
+++ b/adafruit_pybadger/pybadger_base.py
@@ -355,7 +355,7 @@ class PyBadgerBase:
         font,
         scale,
         height_adjustment,
-        background_color=None,
+        font_background_color=None,
         color=0xFFFFFF,
         width_adjustment=2,
         line_spacing=0.75,
@@ -370,7 +370,7 @@ class PyBadgerBase:
             font,
             text=text,
             line_spacing=line_spacing,
-            background_color=background_color,
+            background_color=font_background_color,
         )
         _, _, width, _ = create_label.bounding_box
         create_label.x = (self.display.width // (width_adjustment * scale)) - width // 2
@@ -454,7 +454,7 @@ class PyBadgerBase:
         name_scale=1,
         name_font=terminalio.FONT,
         font_color=0xFFFFFF,
-        background_color=None,
+        font_background_color=None,
         email_string_one=None,
         email_scale_one=1,
         email_font_one=terminalio.FONT,
@@ -500,7 +500,7 @@ class PyBadgerBase:
                 color=font_color,
                 scale=name_scale,
                 height_adjustment=0.73,
-                background_color=background_color,
+                background_color=font_background_color,
             )
             business_card_label_groups.append(name_group)
         if email_string_one:
@@ -510,7 +510,7 @@ class PyBadgerBase:
                 color=font_color,
                 scale=email_scale_one,
                 height_adjustment=0.84,
-                background_color=background_color,
+                background_color=font_background_color,
             )
             business_card_label_groups.append(email_one_group)
         if email_string_two:
@@ -520,7 +520,7 @@ class PyBadgerBase:
                 color=font_color,
                 scale=email_scale_two,
                 height_adjustment=0.91,
-                background_color=background_color,
+                background_color=font_background_color,
             )
             business_card_label_groups.append(email_two_group)
 

--- a/adafruit_pybadger/pybadger_base.py
+++ b/adafruit_pybadger/pybadger_base.py
@@ -355,7 +355,7 @@ class PyBadgerBase:
         font,
         scale,
         height_adjustment,
-        font_background_color=None,
+        background_color=None,
         color=0xFFFFFF,
         width_adjustment=2,
         line_spacing=0.75,

--- a/adafruit_pybadger/pybadger_base.py
+++ b/adafruit_pybadger/pybadger_base.py
@@ -355,6 +355,7 @@ class PyBadgerBase:
         font,
         scale,
         height_adjustment,
+        background_color=None,
         color=0xFFFFFF,
         width_adjustment=2,
         line_spacing=0.75,
@@ -365,7 +366,7 @@ class PyBadgerBase:
             font = load_font(font, text)
 
         create_label_group = displayio.Group(scale=scale)
-        create_label = self._label.Label(font, text=text, line_spacing=line_spacing)
+        create_label = self._label.Label(font, text=text, line_spacing=line_spacing, background_color=background_color)
         _, _, width, _ = create_label.bounding_box
         create_label.x = (self.display.width // (width_adjustment * scale)) - width // 2
         create_label.y = int(self.display.height * (height_adjustment / scale))
@@ -447,6 +448,7 @@ class PyBadgerBase:
         name_string=None,
         name_scale=1,
         name_font=terminalio.FONT,
+        background_color=None,
         email_string_one=None,
         email_scale_one=1,
         email_font_one=terminalio.FONT,
@@ -491,6 +493,7 @@ class PyBadgerBase:
                 font=name_font,
                 scale=name_scale,
                 height_adjustment=0.73,
+                background_color=background_color,
             )
             business_card_label_groups.append(name_group)
         if email_string_one:
@@ -499,6 +502,7 @@ class PyBadgerBase:
                 font=email_font_one,
                 scale=email_scale_one,
                 height_adjustment=0.84,
+                background_color=background_color,
             )
             business_card_label_groups.append(email_one_group)
         if email_string_two:
@@ -507,6 +511,7 @@ class PyBadgerBase:
                 font=email_font_two,
                 scale=email_scale_two,
                 height_adjustment=0.91,
+                background_color=background_color,
             )
             business_card_label_groups.append(email_two_group)
 

--- a/adafruit_pybadger/pybadger_base.py
+++ b/adafruit_pybadger/pybadger_base.py
@@ -448,6 +448,7 @@ class PyBadgerBase:
         name_string=None,
         name_scale=1,
         name_font=terminalio.FONT,
+        font_color=0xFFFFFF,
         background_color=None,
         email_string_one=None,
         email_scale_one=1,
@@ -491,6 +492,7 @@ class PyBadgerBase:
             name_group = self._create_label_group(
                 text=name_string,
                 font=name_font,
+                color=font_color,
                 scale=name_scale,
                 height_adjustment=0.73,
                 background_color=background_color,
@@ -500,6 +502,7 @@ class PyBadgerBase:
             email_one_group = self._create_label_group(
                 text=email_string_one,
                 font=email_font_one,
+                color=font_color,
                 scale=email_scale_one,
                 height_adjustment=0.84,
                 background_color=background_color,
@@ -509,6 +512,7 @@ class PyBadgerBase:
             email_two_group = self._create_label_group(
                 text=email_string_two,
                 font=email_font_two,
+                color=font_color,
                 scale=email_scale_two,
                 height_adjustment=0.91,
                 background_color=background_color,

--- a/adafruit_pybadger/pybadger_base.py
+++ b/adafruit_pybadger/pybadger_base.py
@@ -370,7 +370,7 @@ class PyBadgerBase:
             font,
             text=text,
             line_spacing=line_spacing,
-            background_color=font_background_color,
+            background_color=background_color,
         )
         _, _, width, _ = create_label.bounding_box
         create_label.x = (self.display.width // (width_adjustment * scale)) - width // 2

--- a/adafruit_pybadger/pybadger_base.py
+++ b/adafruit_pybadger/pybadger_base.py
@@ -366,7 +366,12 @@ class PyBadgerBase:
             font = load_font(font, text)
 
         create_label_group = displayio.Group(scale=scale)
-        create_label = self._label.Label(font, text=text, line_spacing=line_spacing, background_color=background_color)
+        create_label = self._label.Label(
+            font,
+            text=text,
+            line_spacing=line_spacing,
+            background_color=background_color,
+        )
         _, _, width, _ = create_label.bounding_box
         create_label.x = (self.display.width // (width_adjustment * scale)) - width // 2
         create_label.y = int(self.display.height * (height_adjustment / scale))


### PR DESCRIPTION
Added a few lines to breakout option to set background color and font color when setting text lines for show_business_card.  
This is my first time playing around with adafruit_pybadger library, and I found the default text color, 0xFFFFFF, and transparent background, did not work with my white image.  
After looking through, the ability was there, just not made available through the pybadger show_business_card.  
I am not a pro - coder, mere tinkerer, so there may be a better way to accomplish this, but just thought I would throw it out there and see what you all thought.  
I can now do this:
` pybadger.show_business_card(
      background_color=0xFFFFFF,
      font_color=0x0000FF, ...`
which makes my font more readable on a white image pallette.  Thanks!