### PR TITLE
Pybadge LC compatibility

### DIFF
--- a/adafruit_pybadger/pybadge.py
+++ b/adafruit_pybadger/pybadge.py
@@ -66,7 +66,7 @@ class PyBadge(PyBadgerBase):
         if i2c is not None:
             _i2c_devices = []
 
-            for i in range(10):
+            for _ in range(10):
                 # try lock 10 times to avoid infinite loop in sphinx build
                 if i2c.try_lock():
                     _i2c_devices = i2c.scan()

--- a/adafruit_pybadger/pybadge.py
+++ b/adafruit_pybadger/pybadge.py
@@ -64,10 +64,14 @@ class PyBadge(PyBadgerBase):
                 self._accelerometer = None
 
         if i2c is not None:
-            while not i2c.try_lock():
-                pass
-            _i2c_devices = i2c.scan()
-            i2c.unlock()
+            _i2c_devices = []
+
+            for i in range(10):
+                # try lock 10 times to avoid infinite loop in sphinx build
+                if i2c.try_lock():
+                    _i2c_devices = i2c.scan()
+                    i2c.unlock()
+                    break
 
             # PyBadge LC doesn't have accelerometer
             if int(0x18) in _i2c_devices or int(0x19) in _i2c_devices:

--- a/adafruit_pybadger/pybadge.py
+++ b/adafruit_pybadger/pybadge.py
@@ -64,13 +64,18 @@ class PyBadge(PyBadgerBase):
                 self._accelerometer = None
 
         if i2c is not None:
-            int1 = digitalio.DigitalInOut(board.ACCELEROMETER_INTERRUPT)
-            try:
-                self._accelerometer = adafruit_lis3dh.LIS3DH_I2C(
-                    i2c, address=0x19, int1=int1
-                )
-            except ValueError:
-                self._accelerometer = adafruit_lis3dh.LIS3DH_I2C(i2c, int1=int1)
+            while not i2c.try_lock():
+                pass
+            _i2c_devices = i2c.scan()
+            i2c.unlock()
+            if (int(0x18) in _i2c_devices):  # PyBadge LC doesn't have accelerometer
+                int1 = digitalio.DigitalInOut(board.ACCELEROMETER_INTERRUPT)
+                try:
+                    self._accelerometer = adafruit_lis3dh.LIS3DH_I2C(
+                        i2c, address=0x19, int1=int1
+                    )
+                except ValueError:
+                    self._accelerometer = adafruit_lis3dh.LIS3DH_I2C(i2c, int1=int1)
 
         # NeoPixels
         self._neopixels = neopixel.NeoPixel(

--- a/adafruit_pybadger/pybadge.py
+++ b/adafruit_pybadger/pybadge.py
@@ -68,7 +68,9 @@ class PyBadge(PyBadgerBase):
                 pass
             _i2c_devices = i2c.scan()
             i2c.unlock()
-            if (int(0x18) in _i2c_devices):  # PyBadge LC doesn't have accelerometer
+
+            # PyBadge LC doesn't have accelerometer
+            if int(0x18) in _i2c_devices or int(0x19) in _i2c_devices:
                 int1 = digitalio.DigitalInOut(board.ACCELEROMETER_INTERRUPT)
                 try:
                     self._accelerometer = adafruit_lis3dh.LIS3DH_I2C(


### PR DESCRIPTION
resolves: #53 

This change will run an `i2c.scan()` and check for the presence of the accelerometer (addresses `0x18` or `0x19`) before attempting to initialize it. I believe this should make the library compatible with the PyBadge LC variant which does not have the accelerometer populated.

I tested the updated library using the simpletest with an Edge Badge to ensure that accelerometer readings are still working normally. 

I don't have the LC variant of the hardware. But it would be great if someone who does can test this change on it as well to ensure there isn't something I missed still causing incompatibility.