### PR TITLE
Fix pylint errors

### DIFF
--- a/adafruit_pybadger/pybadger_base.py
+++ b/adafruit_pybadger/pybadger_base.py
@@ -399,10 +399,10 @@ class PyBadgerBase:
             self._last_accelerometer = current_accelerometer
             return False
         acceleration_delta = sum(
-            [
+            (
                 abs(self._last_accelerometer[n] - current_accelerometer[n])
                 for n in range(3)
-            ]
+            )
         )
         self._last_accelerometer = current_accelerometer
         return acceleration_delta > movement_threshold


### PR DESCRIPTION
Fixed the following `pylint` errors:

```
 ************* Module adafruit_pybadger.pybadger_base
Error: adafruit_pybadger/pybadger_base.py:401:29: R1728: Consider using a generator instead 'sum(abs(self._last_accelerometer[n] - current_accelerometer[n]) for n in range(3))' (consider-using-generator)
```