### PR TITLE
fix doc API build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ extensions = [
 # autodoc module docs will fail to generate with a warning.
 autodoc_mock_imports = [
     "audioio",
+    "bitmaptools",
     "displayio",
     "neopixel",
     "analogio",


### PR DESCRIPTION
The doc build on RTD did not include the API. This is mysterious because it is not failing in the CI. When I built the docs by hand locally, it did fail, and I had to add a mock for `bitmaptools`. I hope this fixes the issue.