### PR TITLE
Replace depreciated .show()

### DIFF
--- a/adafruit_pybadger/pybadger_base.py
+++ b/adafruit_pybadger/pybadger_base.py
@@ -652,7 +652,7 @@ class PyBadgerBase:
         """Show the given group, refreshing the screen immediately"""
         self.activity()
         self.display.auto_refresh = False
-        self.display.show(group)
+        self.display.root_group = group
         self.display.refresh()
         self.display.auto_refresh = True
 


### PR DESCRIPTION
fixes #67 

This library actually wraps the display.root_group assignment in a pybadger.show() method so other than the one change in the pybadger show method, I believe all the example code should work as is.