### PR TITLE
attempt new accelerometer init if first one fails

### DIFF
--- a/adafruit_pybadger/clue.py
+++ b/adafruit_pybadger/clue.py
@@ -30,6 +30,7 @@ import board
 import audiopwmio
 import keypad
 import adafruit_lsm6ds.lsm6ds33
+import adafruit_lsm6ds.lsm6ds3trc
 import neopixel
 from adafruit_pybadger.pybadger_base import PyBadgerBase, KeyStates
 
@@ -51,7 +52,10 @@ class Clue(PyBadgerBase):
         i2c = board.I2C()
 
         if i2c is not None:
-            self._accelerometer = adafruit_lsm6ds.lsm6ds33.LSM6DS33(i2c)
+            try:
+                self._accelerometer = adafruit_lsm6ds.lsm6ds33.LSM6DS33(i2c)
+            except RuntimeError:
+                self._accelerometer = adafruit_lsm6ds.lsm6ds3trc.LSM6DS3TRC(i2c)
 
         # NeoPixels
         self._neopixels = neopixel.NeoPixel(


### PR DESCRIPTION
@ladyada 

I think this should resolve the issue from the most recent post in this thread https://forums.adafruit.com/viewtopic.php?p=1051604#p1051604 It adds the same fix used here: https://github.com/adafruit/Adafruit_CircuitPython_CLUE/pull/65

The referenced learn guide uses this PyBadger library not the CLUE library, so the update from a few months ago wasn't in use by that learn guide. 

I have only older CLUE devices, so cant test the new driver specifically, but I did test this version with the learn guide code and confirmed it runs and has access to acceleration data.
