### PR TITLE
Fix docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,6 @@ autodoc_mock_imports = [
     "adafruit_lsm6ds",
     "audiocore",
     "audiopwmio",
-    "micropython",
     "terminalio",
     "digitalio",
     "board",


### PR DESCRIPTION
The actions in this repo failed after the recent patch and release sweep. The root cause was with usage of micropython.const.

The fix is to remove micropython from mocked docs list which allows it to use the instance defined in Blinka that does not result in the same build errors.